### PR TITLE
add get nodepool join config

### DIFF
--- a/pkg/acloudapi/apitypes.go
+++ b/pkg/acloudapi/apitypes.go
@@ -169,6 +169,22 @@ type NodeTaint struct {
 	Effect string `json:"effect"`
 }
 
+type NodePoolJoinConfig struct {
+	Versions                NodeJoinConfigVersions `json:"versions"`
+	CloudInitUserDataBase64 string                 `json:"cloudInitUserDataBase64"`
+	InstallScriptBase64     string                 `json:"installScriptBase64"`
+	UpgradeScriptBase64     string                 `json:"upgradeScriptBase64"`
+	JoinCommand             string                 `json:"joinCommand"`
+	KubeletConfigBase64     string                 `json:"kubeletConfigBase64"`
+}
+
+type NodeJoinConfigVersions struct {
+	CloudInit  string `json:"cloudInit"`
+	Kubernetes string `json:"kubernetes"`
+	Containerd string `json:"containerd"`
+	Crictl     string `json:"crictl"`
+}
+
 func (n NodePool) FullIdentifier() string {
 	c := n.Cluster
 	return fmt.Sprintf("%s/%s/%s/%s (%d)", c.CustomerSlug, c.EnvironmentSlug, c.Slug, n.Name, n.ID)

--- a/pkg/acloudapi/client.go
+++ b/pkg/acloudapi/client.go
@@ -47,6 +47,7 @@ type NodePoolsAPI interface {
 	GetNodePoolsByOrg(ctx context.Context, organisationSlug string) ([]NodePool, error)
 	GetNodePoolsByCluster(ctx context.Context, cluster Cluster) ([]NodePool, error)
 	GetNodePoolsByClusters(ctx context.Context, clusters []Cluster) ([]NodePool, error)
+	GetNodePoolJoinConfig(ctx context.Context, cluster Cluster, nodePool NodePool) (*NodePoolJoinConfig, error)
 	CreateNodePool(ctx context.Context, cluster Cluster, create CreateNodePool) (*NodePool, error)
 	UpdateNodePool(ctx context.Context, cluster Cluster, nodePoolID int, update CreateNodePool) (*NodePool, error)
 	DeleteNodePool(ctx context.Context, cluster Cluster, nodePoolID int) error

--- a/pkg/acloudapi/nodepool_join_config.go
+++ b/pkg/acloudapi/nodepool_join_config.go
@@ -1,0 +1,18 @@
+package acloudapi
+
+import (
+	"context"
+	"fmt"
+)
+
+func (c *clientImpl) GetNodePoolJoinConfig(ctx context.Context, cluster Cluster, nodePool NodePool) (*NodePoolJoinConfig, error) {
+	joinConfig := NodePoolJoinConfig{}
+	response, err := c.R().
+		SetContext(ctx).
+		SetResult(&joinConfig).
+		Post(fmt.Sprintf("/api/v1/orgs/%s/clusters/%s/%s/pools/%s/join-config", cluster.CustomerSlug, cluster.EnvironmentSlug, cluster.Slug, nodePool.Identity))
+	if err := c.CheckResponse(response, err); err != nil {
+		return nil, err
+	}
+	return &joinConfig, nil
+}


### PR DESCRIPTION
This adds support for fetching the node pool join config, which we can use for terraform and acloud.
