### PR TITLE
AME-2920 Add new admin api endpoints related to auto cluster upgrades

### DIFF
--- a/pkg/acloudapi/admin_client.go
+++ b/pkg/acloudapi/admin_client.go
@@ -8,15 +8,31 @@ import (
 
 type AdminClusterAPI interface {
 	GetCluster(ctx context.Context, clusterIdentity string, opts ...GetClusterOpts) (*Cluster, error)
+	ListClusters(ctx context.Context, opts ...GetClusterOpts) ([]Cluster, error)
+	UpdateCluster(ctx context.Context, request AdminUpdateClusterRequest) (*Cluster, error)
 }
 
 type AdminOrganisationAPI interface {
 	GetOrganisation(ctx context.Context, organisationIdentity string) (*AdminOrganisation, error)
 }
 
+type AdminScheduledClusterUpgradesAPI interface {
+	ListScheduledClusterUpgrades(ctx context.Context, opts ...ListScheduledClusterUpgradesOpts) ([]ScheduledClusterUpgrade, error)
+	GetScheduledClusterUpgrade(ctx context.Context, identity string) (*ScheduledClusterUpgrade, error)
+	CancelScheduledClusterUpgrade(ctx context.Context, identity string) (*ScheduledClusterUpgrade, error)
+	CreateScheduledClusterUpgrade(ctx context.Context, request CreateScheduledClusterUpgradeRequest) (*ScheduledClusterUpgrade, error)
+	UpdateScheduledClusterUpgrade(ctx context.Context, request UpdateScheduledClusterUpgradeRequest) (*ScheduledClusterUpgrade, error)
+}
+
+type AdminUpdateChannelsAPI interface {
+	ListUpdateChannels(ctx context.Context) ([]UpdateChannelResponse, error)
+}
+
 type AdminClient interface {
 	AdminClusterAPI
 	AdminOrganisationAPI
+	AdminScheduledClusterUpgradesAPI
+	AdminUpdateChannelsAPI
 
 	Resty() *resty.Client
 }

--- a/pkg/acloudapi/admin_clusters.go
+++ b/pkg/acloudapi/admin_clusters.go
@@ -18,3 +18,39 @@ func (c *adminClientImpl) GetCluster(ctx context.Context, clusterIdentity string
 	FixCluster(&cluster, cluster.CustomerSlug)
 	return &cluster, nil
 }
+
+func (c *adminClientImpl) ListClusters(ctx context.Context, opts ...GetClusterOpts) ([]Cluster, error) {
+	queryParams := GetClusterOptsToQueryParams(opts, GetClusterOpts{IncludeDetails: True(), ShowCompute: True(), HideDeleted: True()})
+	all, err := c.GetPaged(ctx, fmt.Sprintf("/admin/v1/clusters%s", OptionalQueryParams(queryParams)))
+	if err != nil {
+		return nil, err
+	}
+	content, err := MarshalPagedResultContent[Cluster](all)
+	if err != nil {
+		return nil, err
+	}
+	for i, _ := range content {
+		item := &content[i]
+		FixCluster(item, item.CustomerSlug)
+	}
+	return content, nil
+}
+
+func (c *adminClientImpl) UpdateCluster(ctx context.Context, request AdminUpdateClusterRequest) (*Cluster, error) {
+	cluster := Cluster{}
+	response, err := c.R().
+		SetContext(ctx).
+		SetResult(&cluster).
+		SetBody(&request).
+		Put(fmt.Sprintf("/admin/v1/clusters/%s", request.ClusterIdentity))
+	if err := c.CheckResponse(response, err); err != nil {
+		return nil, err
+	}
+	FixCluster(&cluster, cluster.CustomerSlug)
+	return &cluster, nil
+}
+
+type AdminUpdateClusterRequest struct {
+	ClusterIdentity string `json:"clusterIdentity"`
+	Version         string `json:"version"`
+}

--- a/pkg/acloudapi/admin_scheduledclusterupgrades.go
+++ b/pkg/acloudapi/admin_scheduledclusterupgrades.go
@@ -1,0 +1,65 @@
+package acloudapi
+
+import (
+	"context"
+	"fmt"
+)
+
+func (c *adminClientImpl) ListScheduledClusterUpgrades(ctx context.Context, opts ...ListScheduledClusterUpgradesOpts) ([]ScheduledClusterUpgrade, error) {
+	queryParams := ListScheduledClusterUpgradesOptsToQueryParams(opts, ListScheduledClusterUpgradesOpts{})
+	all, err := c.GetPaged(ctx, fmt.Sprintf("/admin/v1/scheduled-cluster-upgrades%s", OptionalQueryParams(queryParams)))
+	if err != nil {
+		return nil, err
+	}
+	return MarshalPagedResultContent[ScheduledClusterUpgrade](all)
+}
+
+func (c *adminClientImpl) GetScheduledClusterUpgrade(ctx context.Context, identity string) (*ScheduledClusterUpgrade, error) {
+	scheduledClusterUpgrade := ScheduledClusterUpgrade{}
+	response, err := c.R().
+		SetContext(ctx).
+		SetResult(&scheduledClusterUpgrade).
+		Get(fmt.Sprintf("/admin/v1/scheduled-cluster-upgrades/%s", identity))
+	if err := c.CheckResponse(response, err); err != nil {
+		return nil, err
+	}
+	return &scheduledClusterUpgrade, nil
+}
+
+func (c *adminClientImpl) CancelScheduledClusterUpgrade(ctx context.Context, identity string) (*ScheduledClusterUpgrade, error) {
+	scheduledClusterUpgrade := ScheduledClusterUpgrade{}
+	response, err := c.R().
+		SetContext(ctx).
+		SetResult(&scheduledClusterUpgrade).
+		Delete(fmt.Sprintf("/admin/v1/scheduled-cluster-upgrades/%s", identity))
+	if err := c.CheckResponse(response, err); err != nil {
+		return nil, err
+	}
+	return &scheduledClusterUpgrade, nil
+}
+
+func (c *adminClientImpl) CreateScheduledClusterUpgrade(ctx context.Context, request CreateScheduledClusterUpgradeRequest) (*ScheduledClusterUpgrade, error) {
+	scheduledClusterUpgrade := ScheduledClusterUpgrade{}
+	response, err := c.R().
+		SetContext(ctx).
+		SetResult(&scheduledClusterUpgrade).
+		SetBody(&request).
+		Post("/admin/v1/scheduled-cluster-upgrades")
+	if err := c.CheckResponse(response, err); err != nil {
+		return nil, err
+	}
+	return &scheduledClusterUpgrade, nil
+}
+
+func (c *adminClientImpl) UpdateScheduledClusterUpgrade(ctx context.Context, request UpdateScheduledClusterUpgradeRequest) (*ScheduledClusterUpgrade, error) {
+	scheduledClusterUpgrade := ScheduledClusterUpgrade{}
+	response, err := c.R().
+		SetContext(ctx).
+		SetResult(&scheduledClusterUpgrade).
+		SetBody(&request).
+		Put(fmt.Sprintf("/admin/v1/scheduled-cluster-upgrades/%s", request.Identity))
+	if err := c.CheckResponse(response, err); err != nil {
+		return nil, err
+	}
+	return &scheduledClusterUpgrade, nil
+}

--- a/pkg/acloudapi/admin_updatechannels.go
+++ b/pkg/acloudapi/admin_updatechannels.go
@@ -1,0 +1,13 @@
+package acloudapi
+
+import (
+	"context"
+)
+
+func (c *adminClientImpl) ListUpdateChannels(ctx context.Context) ([]UpdateChannelResponse, error) {
+	all, err := c.GetPaged(ctx, "/admin/v1/update-channels")
+	if err != nil {
+		return nil, err
+	}
+	return MarshalPagedResultContent[UpdateChannelResponse](all)
+}

--- a/pkg/acloudapi/apitypes.go
+++ b/pkg/acloudapi/apitypes.go
@@ -44,6 +44,23 @@ type Cluster struct {
 	Addons                       map[string]APIAddon    `json:"addons" yaml:"Addons,omitempty"`
 	ObservabilityTenant          *ObservabilityTenant   `json:"observabilityTenant,omitempty" yaml:"ObservabilityTenant,omitempty"`
 	EnvironmentPrometheusRules   bool                   `json:"environmentPrometheusRules" yaml:"EnvironmentPrometheusRules"`
+	MaintenanceSchedule          *MaintenanceSchedule   `json:"maintenanceSchedule,omitempty" yaml:"MaintenanceSchedule,omitempty"`
+}
+
+type MaintenanceSchedule struct {
+	Identity           string              `json:"identity" yaml:"Identity"`
+	Name               string              `json:"name" yaml:"nName"`
+	MaintenanceWindows []MaintenanceWindow `json:"windows" yaml:"MaintenanceWindows"`
+}
+
+type MaintenanceWindow struct {
+	Day       string `json:"day" yaml:"Day"`
+	StartTime string `json:"startTime" yaml:"StartTime"`
+	Duration  int    `json:"duration" yaml:"duration"`
+}
+
+func (m MaintenanceWindow) String() string {
+	return fmt.Sprintf("%s %s %d minutes", m.Day, m.StartTime, m.Duration)
 }
 
 // IpWhitelistResponse represents the response structure for IP whitelist information.
@@ -347,4 +364,47 @@ type SilenceMatcher struct {
 	Value   string `json:"value" yaml:"Value"`
 	IsRegex bool   `json:"isRegex" yaml:"IsRegex"`
 	IsEqual bool   `json:"isEqual" yaml:"IsEqual"`
+}
+
+type ScheduledClusterUpgrade struct {
+	Identity           string                        `json:"identity" yaml:"Identity"`
+	ClusterIdentity    string                        `json:"clusterIdentity" yaml:"ClusterIdentity"`
+	CreatedAt          time.Time                     `json:"createdAt" yaml:"CreatedAt"`
+	ModifiedAt         time.Time                     `json:"modifiedAt" yaml:"ModifiedAt"`
+	WindowStart        time.Time                     `json:"windowStart" yaml:"WindowStart"`
+	WindowEnd          time.Time                     `json:"windowEnd" yaml:"WindowEnd"`
+	FromClusterVersion string                        `json:"fromClusterVersion" yaml:"FromClusterVersion"`
+	ToClusterVersion   string                        `json:"toClusterVersion" yaml:"ToClusterVersion"`
+	Status             ScheduledClusterUpgradeStatus `json:"status" yaml:"Status"`
+}
+
+type ScheduledClusterUpgradeStatus string
+
+const (
+	Scheduled         ScheduledClusterUpgradeStatus = "SCHEDULED"
+	ScheduledNotified ScheduledClusterUpgradeStatus = "SCHEDULED_NOTIFIED"
+	Updated           ScheduledClusterUpgradeStatus = "UPDATED"
+	Succeeded         ScheduledClusterUpgradeStatus = "SUCCEEDED"
+	Cancelled         ScheduledClusterUpgradeStatus = "CANCELLED"
+	Superseded        ScheduledClusterUpgradeStatus = "SUPERSEDED"
+	Failed            ScheduledClusterUpgradeStatus = "FAILED"
+	Missed            ScheduledClusterUpgradeStatus = "MISSED"
+)
+
+type CreateScheduledClusterUpgradeRequest struct {
+	ClusterIdentity    string    `json:"clusterIdentity"`
+	WindowStart        time.Time `json:"windowStart"`
+	WindowEnd          time.Time `json:"windowEnd"`
+	FromClusterVersion string    `json:"fromClusterVersion"`
+	ToClusterVersion   string    `json:"toClusterVersion"`
+}
+
+type UpdateScheduledClusterUpgradeRequest struct {
+	Identity string                        `json:"identity"`
+	Status   ScheduledClusterUpgradeStatus `json:"status"`
+}
+
+type ListScheduledClusterUpgradesOpts struct {
+	ClusterIdentities []string
+	Statuses          []ScheduledClusterUpgradeStatus
 }

--- a/pkg/acloudapi/clusters.go
+++ b/pkg/acloudapi/clusters.go
@@ -189,6 +189,7 @@ func FixStatus(status string) string {
 type GetClusterOpts struct {
 	IncludeDetails *bool
 	ShowCompute    *bool
+	HideDeleted    *bool // admin-api only
 }
 
 func OptionalQueryParams(queryParams string) string {
@@ -211,6 +212,9 @@ func mergeGetClusterOpts(opts []GetClusterOpts, defaults GetClusterOpts) GetClus
 		if opt.ShowCompute != nil {
 			merged.ShowCompute = opt.ShowCompute
 		}
+		if opt.HideDeleted != nil {
+			merged.HideDeleted = opt.HideDeleted
+		}
 	}
 	return setDefaults(merged, defaults)
 }
@@ -220,7 +224,10 @@ func setDefaults(merged GetClusterOpts, defaults GetClusterOpts) GetClusterOpts 
 		merged.IncludeDetails = defaults.IncludeDetails
 	}
 	if merged.ShowCompute == nil {
-		merged.ShowCompute = defaults.IncludeDetails
+		merged.ShowCompute = defaults.ShowCompute
+	}
+	if merged.HideDeleted == nil {
+		merged.HideDeleted = defaults.HideDeleted
 	}
 	return merged
 }
@@ -235,6 +242,12 @@ func toQueryParams(mergedGetClusterOpts GetClusterOpts) string {
 			url = fmt.Sprintf("%s&", url)
 		}
 		url = fmt.Sprintf("%sshow-compute=%t", url, *mergedGetClusterOpts.ShowCompute)
+	}
+	if mergedGetClusterOpts.HideDeleted != nil {
+		if len(url) > 0 {
+			url = fmt.Sprintf("%s&", url)
+		}
+		url = fmt.Sprintf("%shideDeleted=%t", url, *mergedGetClusterOpts.HideDeleted)
 	}
 	return url
 }

--- a/pkg/acloudapi/scheduledclusterupgrades.go
+++ b/pkg/acloudapi/scheduledclusterupgrades.go
@@ -1,0 +1,51 @@
+package acloudapi
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ListScheduledClusterUpgradesOptsToQueryParams(opts []ListScheduledClusterUpgradesOpts, defaults ListScheduledClusterUpgradesOpts) string {
+	return toQueryParamsListScheduledClusterUpgradesOpts(mergeListScheduledClusterUpgradesOpts(opts, defaults))
+}
+
+func mergeListScheduledClusterUpgradesOpts(opts []ListScheduledClusterUpgradesOpts, defaults ListScheduledClusterUpgradesOpts) ListScheduledClusterUpgradesOpts {
+	merged := ListScheduledClusterUpgradesOpts{}
+	for _, opt := range opts {
+		if opt.ClusterIdentities != nil {
+			merged.ClusterIdentities = opt.ClusterIdentities
+		}
+		if opt.Statuses != nil {
+			merged.Statuses = opt.Statuses
+		}
+	}
+	return setDefaultsListScheduledClusterUpgradesOpts(merged, defaults)
+}
+
+func setDefaultsListScheduledClusterUpgradesOpts(merged ListScheduledClusterUpgradesOpts, defaults ListScheduledClusterUpgradesOpts) ListScheduledClusterUpgradesOpts {
+	if merged.ClusterIdentities == nil {
+		merged.ClusterIdentities = defaults.ClusterIdentities
+	}
+	if merged.Statuses == nil {
+		merged.Statuses = defaults.Statuses
+	}
+	return merged
+}
+
+func toQueryParamsListScheduledClusterUpgradesOpts(opts ListScheduledClusterUpgradesOpts) string {
+	url := ""
+	if opts.ClusterIdentities != nil {
+		url = fmt.Sprintf("clusterIdentities=%s", strings.Join(opts.ClusterIdentities, ","))
+	}
+	if opts.Statuses != nil {
+		if len(url) > 0 {
+			url = fmt.Sprintf("%s&", url)
+		}
+		stringSlice := make([]string, len(opts.Statuses))
+		for i, item := range opts.Statuses {
+			stringSlice[i] = string(item)
+		}
+		url = fmt.Sprintf("%sstatuses=%s", url, strings.Join(stringSlice, ","))
+	}
+	return url
+}


### PR DESCRIPTION
Api:
- Add MaintenanceSchedule field to Cluster
- Fixes bug with default showCompute in GetClusterOpts

Admin api:

- add all ScheduledClusterUpgrades endpoints
- add list UpdateChannels
- add list Clusters
- add update Cluster