### PR TITLE
add cloudaccounts and get cloud profiles

### DIFF
--- a/pkg/acloudapi/client.go
+++ b/pkg/acloudapi/client.go
@@ -55,7 +55,11 @@ type NodePoolsAPI interface {
 
 type CloudAccountsAPI interface {
 	GetCloudAccounts(ctx context.Context, org string) ([]CloudAccount, error)
+	CreateCloudAccount(ctx context.Context, org string, createCloudAccount CreateCloudAccount) (*CloudAccount, error)
+	UpdateCloudAccount(ctx context.Context, org, cloudAccount string, updateCloudAccount UpdateCloudAccount) (*CloudAccount, error)
+	DeleteCloudAccount(ctx context.Context, org, cloudAccount string) error
 	FindCloudAccountByName(ctx context.Context, org, name, cloudProvider string) (*CloudAccount, error)
+	GetCloudProfiles(ctx context.Context, org string) ([]CloudProfile, error)
 }
 
 type MembershipsAPI interface {

--- a/pkg/acloudapi/cloudaccounts.go
+++ b/pkg/acloudapi/cloudaccounts.go
@@ -6,12 +6,44 @@ import (
 )
 
 type CloudAccount struct {
-	Identity                        string            `json:"identity"`
-	DisplayName                     string            `json:"displayName"`
-	Metadata                        map[string]string `json:"metadata"`
-	CloudProfile                    CloudProfile      `json:"cloudProfile"`
-	Enabled                         bool              `json:"enabled"`
-	PrimaryCloudCredentialsIdentity string            `json:"primaryCloudCredentialsIdentity"`
+	Identity                        string               `json:"identity"`
+	DisplayName                     string               `json:"displayName"`
+	Metadata                        CloudAccountMetadata `json:"metadata"`
+	CloudProfile                    CloudProfile         `json:"cloudProfile"`
+	Enabled                         bool                 `json:"enabled"`
+	PrimaryCloudCredentialsIdentity string               `json:"primaryCloudCredentialsIdentity"`
+}
+
+type CloudAccountMetadata struct {
+	// VsphereParentResourcePool is the parent resource pool for the vSphere cloud account. Required for Vsphere
+	VSphereParentResourcePool *string `json:"parentResourcePool,omitempty"`
+	// VSphereParentFolder is the parent folder for the vSphere cloud account. Required for Vsphere
+	VsphereParentFolder *string `json:"parentFolder,omitempty"`
+
+	// OpenStackTenantID is the ID of the OpenStack tenant. Optional
+	OpenStackTenantID *string `json:"tenantId,omitempty"`
+}
+
+type CreateCloudAccount struct {
+	// DisplayName is the name of the cloud account
+	DisplayName string `json:"displayName"`
+	// CloudProfile is the identity of the cloud profile to use
+	CloudProfile string `json:"cloudProfile"`
+
+	// Metadata is a map of additional information for the cloud account
+	// See https://docs.avisi.cloud for more information
+	Metadata CloudAccountMetadata `json:"metadata"`
+}
+
+type UpdateCloudAccount struct {
+	// DisplayName is the name of the cloud account
+	DisplayName string `json:"displayName"`
+
+	// Enabled is a flag to enable or disable the cloud account
+	Enabled bool `json:"enabled"`
+
+	// PrimaryCloudCredentials is the identity of the primary cloud credentials to use
+	PrimaryCloudCredentials string `json:"primaryCloudCredentials"`
 }
 
 type CloudProfile struct {
@@ -56,4 +88,57 @@ func (c *clientImpl) FindCloudAccountByName(ctx context.Context, org, name, clou
 	result := cloudAccounts[0]
 
 	return &result, nil
+}
+
+func (c *clientImpl) CreateCloudAccount(ctx context.Context, org string, create CreateCloudAccount) (*CloudAccount, error) {
+	cloudAccount := CloudAccount{}
+	response, err := c.R().
+		SetContext(ctx).
+		SetResult(&cloudAccount).
+		SetBody(&create).
+		Post(fmt.Sprintf("/api/v1/orgs/%s/cloud-accounts", org))
+	if err := c.CheckResponse(response, err); err != nil {
+		return nil, err
+	}
+	return &cloudAccount, nil
+}
+
+// UpdateCloudAccount updates the cloud account with the given identity
+func (c *clientImpl) UpdateCloudAccount(ctx context.Context, org, identity string, update UpdateCloudAccount) (*CloudAccount, error) {
+	cloudAccount := CloudAccount{}
+	response, err := c.R().
+		SetContext(ctx).
+		SetResult(&cloudAccount).
+		SetBody(&update).
+		Patch(fmt.Sprintf("/api/v1/orgs/%s/cloud-accounts/%s", org, identity))
+	if err := c.CheckResponse(response, err); err != nil {
+		return nil, err
+	}
+	return &cloudAccount, nil
+}
+
+// DeleteCloudAccount deletes the cloud account with the given identity
+func (c *clientImpl) DeleteCloudAccount(ctx context.Context, org, identity string) error {
+	response, err := c.R().
+		SetContext(ctx).
+		Delete(fmt.Sprintf("/api/v1/orgs/%s/cloud-accounts/%s", org, identity))
+	if err := c.CheckResponse(response, err); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetCloudProfiles returns a list of cloud profiles for the given organization
+// The cloud profiles are used to create cloud accounts
+// The cloud profiles contain information about the cloud provider and the regions available
+func (c *clientImpl) GetCloudProfiles(ctx context.Context, org string) ([]CloudProfile, error) {
+	cloudProfiles := []CloudProfile{}
+	response, err := c.R().
+		SetContext(ctx).
+		SetResult(&cloudProfiles).
+		Get(fmt.Sprintf("/api/v1/orgs/%s/cloud-profiles", org))
+	if err := c.CheckResponse(response, err); err != nil {
+		return nil, err
+	}
+	return cloudProfiles, nil
 }


### PR DESCRIPTION
Add cloudaccounts and get cloud profiles.

Implements:

- [List cloud accounts in an organisation.](https://docs.avisi.cloud/rest/api/v1/cloud-accounts/#list-cloud-accounts-in-an-organisation)
- [Create a cloud account in an organisation.](https://docs.avisi.cloud/rest/api/v1/cloud-accounts/#create-a-cloud-account-in-an-organisation)
- [Delete a cloud account from an organisation (only possible if the cloud account was not used by a cluster the last 24 hours).](https://docs.avisi.cloud/rest/api/v1/cloud-accounts/#delete-a-cloud-account-from-an-organisation-only-possible-if-the-cloud-account-was-not-used-by-a-cluster-the-last-24-hours)
- [Get a cloud account in an organisation.](https://docs.avisi.cloud/rest/api/v1/cloud-accounts/#get-a-cloud-account-in-an-organisation)
- [List available cloud profiles for an organisation.](https://docs.avisi.cloud/rest/api/v1/cloud-profiles/#list-available-cloud-profiles-for-an-organisation)

