### PR TITLE
fix(api): AME-3547 add enableNodeReboots to node pool

### DIFF
--- a/pkg/acloudapi/apitypes.go
+++ b/pkg/acloudapi/apitypes.go
@@ -300,6 +300,7 @@ type CreateNodePool struct {
 	MaxSize             int                     `json:"maxSize" yaml:"MaxSize"`
 	AutoScaling         bool                    `json:"autoScaling" yaml:"AutoScaling"`
 	NodeAutoReplacement bool                    `json:"enableNodeAutoReplacement" yaml:"EnableNodeAutoReplacement"`
+	EnableNodeReboots   bool                    `json:"enableNodeReboots" yaml:"EnableNodeReboots"`
 	UpgradeStrategy     NodePoolUpgradeStrategy `json:"upgradeStrategy,omitempty" yaml:"UpgradeStrategy"`
 	Annotations         map[string]string       `json:"annotations" yaml:"Annotations"`
 	Labels              map[string]string       `json:"labels" yaml:"Labels"`


### PR DESCRIPTION
Added the `EnableNodeReboots` boolean field to the `CreateNodePool` struct. 

This field allows configuration of automatic node reboots as part of the node pool lifecycle management.

Jira ticket: AME-3547