### PR TITLE
fix(authenticator): fix personal access token authenticator

### DIFF
--- a/pkg/acloudapi/authenticator.go
+++ b/pkg/acloudapi/authenticator.go
@@ -19,7 +19,7 @@ func NewPersonalAccessTokenAuthenticator(token string) Authenticator {
 }
 
 func (m *personalAccessTokenAuthenticator) Authenticate(c *resty.Client, r *resty.Request) error {
-	c.SetAuthScheme("Token")
-	c.SetAuthToken(m.token)
+	r.SetAuthScheme("Token")
+	r.SetAuthToken(m.token)
 	return nil
 }


### PR DESCRIPTION
Fixes the personal access token authenticator by setting the authentication scheme and token on the request instead of on the Resty client.