### PR TITLE
Fix YAML tag for MaintenanceSchedule Name

### DIFF
--- a/pkg/acloudapi/apitypes.go
+++ b/pkg/acloudapi/apitypes.go
@@ -73,7 +73,7 @@ type UpstreamCluster struct {
 
 type MaintenanceSchedule struct {
 	Identity           string              `json:"identity" yaml:"Identity"`
-	Name               string              `json:"name" yaml:"nName"`
+	Name               string              `json:"name" yaml:"Name"`
 	MaintenanceWindows []MaintenanceWindow `json:"windows" yaml:"MaintenanceWindows"`
 }
 


### PR DESCRIPTION
## Summary
- correct the `yaml` tag for `MaintenanceSchedule.Name`

## Testing
- `go test ./...` *(fails: downloading go toolchain blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68529cda36708332b5348c73327c2f0a