### PR TITLE
Fix CreateCloudCredential result parsing

### DIFF
--- a/pkg/acloudapi/cloudcredentials.go
+++ b/pkg/acloudapi/cloudcredentials.go
@@ -132,7 +132,7 @@ func (c *clientImpl) CreateCloudCredential(ctx context.Context, org string, clou
 	credentials := CloudCredential{}
 	response, err := c.R().
 		SetContext(ctx).
-		SetResult(&cloudAccount).
+		SetResult(&credentials).
 		SetBody(&create).
 		Post(fmt.Sprintf("/api/v1/orgs/%s/cloud-accounts/%s/credentials/%s", org, cloudAccount.Identity, cloudType))
 	if err := c.CheckResponse(response, err); err != nil {


### PR DESCRIPTION
## Summary
- ensure CreateCloudCredential parses the created credential properly

## Testing
- `GOTOOLCHAIN=local go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6852a1963c1083328c965585ab9b14d5