### PR TITLE
fix: handle nil response in CheckResponse

### DIFF
--- a/pkg/acloudapi/restyclient.go
+++ b/pkg/acloudapi/restyclient.go
@@ -154,6 +154,13 @@ func NewDefaultRestyClient(authenticator Authenticator, opts ClientOpts, client 
 }
 
 func (c *RestyClient) CheckResponse(response *resty.Response, err error) error {
+	if response == nil {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("no response received")
+	}
+
 	if c.opts.Trace {
 		fmt.Printf("~~~ TRACE %s %s%s ~~~\n", response.Request.Method, c.opts.APIUrl, response.Request.URL)
 		ti := response.Request.TraceInfo()

--- a/pkg/acloudapi/restyclient_test.go
+++ b/pkg/acloudapi/restyclient_test.go
@@ -1,0 +1,42 @@
+package acloudapi
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRestyClient_CheckResponse(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{"message":"ok"}`)
+		}))
+		defer server.Close()
+
+		c := NewRestyClient(nil, ClientOpts{APIUrl: server.URL})
+		resp, err := c.R().Get("/")
+		if err != nil {
+			t.Fatalf("unexpected request error: %v", err)
+		}
+		if err := c.CheckResponse(resp, err); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("nil response without trace", func(t *testing.T) {
+		c := NewRestyClient(nil, ClientOpts{})
+		err := c.CheckResponse(nil, nil)
+		if err == nil || err.Error() != "no response received" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nil response with trace", func(t *testing.T) {
+		c := NewRestyClient(nil, ClientOpts{Trace: true})
+		err := c.CheckResponse(nil, nil)
+		if err == nil || err.Error() != "no response received" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- avoid dereferencing nil responses in `CheckResponse`
- return explicit error when no response is received
- add unit tests covering successful response and nil response scenarios

## Testing
- `go test ./...` *(fails: downloading Go toolchain blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68540ffd88f48332b71fe8c2b09f39b4