### PR TITLE
feat(acloudapi): AME-4155 add node pool securityUpdatesOnJoin

### DIFF
--- a/pkg/acloudapi/apitypes.go
+++ b/pkg/acloudapi/apitypes.go
@@ -209,6 +209,8 @@ type NodePools struct {
 	NodeSize         string                  `json:"nodeSize" yaml:"NodeSize"`
 	AvailabilityZone string                  `json:"availabilityZone,omitempty" yaml:"AvailabilityZone,omitempty"`
 	UpgradeStrategy  NodePoolUpgradeStrategy `json:"upgradeStrategy" yaml:"UpgradeStrategy"`
+	// SecurityUpdatesOnJoin is omitted when empty: the server then defaults to OFF on create and keeps the stored value on update.
+	SecurityUpdatesOnJoin NodePoolSecurityUpdatesOnJoin `json:"securityUpdatesOnJoin,omitempty" yaml:"SecurityUpdatesOnJoin,omitempty"`
 }
 
 // NodePool represents a pool of nodes in a cluster.
@@ -224,12 +226,15 @@ type NodePool struct {
 	NodeAutoReplacement bool                    `json:"enableNodeAutoReplacement" yaml:"EnableNodeAutoReplacement"`
 	EnableNodeReboots   bool                    `json:"enableNodeReboots" yaml:"EnableNodeReboots"`
 	UpgradeStrategy     NodePoolUpgradeStrategy `json:"upgradeStrategy" yaml:"UpgradeStrategy"`
-	Annotations         map[string]string       `json:"annotations" yaml:"Annotations"`
-	Labels              map[string]string       `json:"labels" yaml:"Labels"`
-	Taints              []NodeTaint             `json:"taints" yaml:"Taints"`
-	ProvisionStatus     string                  `json:"provisionStatus" yaml:"ProvisionStatus,omitempty"`
-	CreatedAt           time.Time               `json:"createdAt" yaml:"CreatedAt,omitempty"`
-	ModifiedAt          time.Time               `json:"modifiedAt" yaml:"ModifiedAt,omitempty"`
+	// SecurityUpdatesOnJoin controls whether OS security updates are installed during node bring-up,
+	// before the node joins the cluster. Applies to the first join only, not to upgrades of existing nodes.
+	SecurityUpdatesOnJoin NodePoolSecurityUpdatesOnJoin `json:"securityUpdatesOnJoin" yaml:"SecurityUpdatesOnJoin"`
+	Annotations           map[string]string             `json:"annotations" yaml:"Annotations"`
+	Labels                map[string]string             `json:"labels" yaml:"Labels"`
+	Taints                []NodeTaint                   `json:"taints" yaml:"Taints"`
+	ProvisionStatus       string                        `json:"provisionStatus" yaml:"ProvisionStatus,omitempty"`
+	CreatedAt             time.Time                     `json:"createdAt" yaml:"CreatedAt,omitempty"`
+	ModifiedAt            time.Time                     `json:"modifiedAt" yaml:"ModifiedAt,omitempty"`
 
 	ClusterIdentity string  `json:"clusterIdentity" yaml:"ClusterIdentity,omitempty"` // adds a reference to Cluster
 	Cluster         Cluster `json:"-" yaml:"-"`                                       // adds a reference to Cluster for in-code
@@ -261,6 +266,35 @@ func ParseNodePoolUpgradeStrategy(s string) (NodePoolUpgradeStrategy, error) {
 		}
 	}
 	return "", fmt.Errorf("unsupported upgrade strategy: %s", s)
+}
+
+// NodePoolSecurityUpdatesOnJoin represents whether OS security updates are installed during node bring-up,
+// before the node joins the cluster. Applies to the first join only, not to upgrades of existing nodes.
+type NodePoolSecurityUpdatesOnJoin string
+
+const (
+	// NodePoolSecurityUpdatesOnJoinOff disables installing OS security updates during node bring-up.
+	NodePoolSecurityUpdatesOnJoinOff NodePoolSecurityUpdatesOnJoin = "OFF"
+	// NodePoolSecurityUpdatesOnJoinInstall installs OS security updates during node bring-up, before the node joins the cluster.
+	NodePoolSecurityUpdatesOnJoinInstall NodePoolSecurityUpdatesOnJoin = "INSTALL"
+	// NodePoolSecurityUpdatesOnJoinInstallAndReboot installs OS security updates during node bring-up and,
+	// if required, reboots the node before it joins the cluster.
+	NodePoolSecurityUpdatesOnJoinInstallAndReboot NodePoolSecurityUpdatesOnJoin = "INSTALL_AND_REBOOT"
+)
+
+var AllNodePoolSecurityUpdatesOnJoin = []NodePoolSecurityUpdatesOnJoin{
+	NodePoolSecurityUpdatesOnJoinOff,
+	NodePoolSecurityUpdatesOnJoinInstall,
+	NodePoolSecurityUpdatesOnJoinInstallAndReboot,
+}
+
+func ParseNodePoolSecurityUpdatesOnJoin(s string) (NodePoolSecurityUpdatesOnJoin, error) {
+	for _, securityUpdatesOnJoin := range AllNodePoolSecurityUpdatesOnJoin {
+		if string(securityUpdatesOnJoin) == s {
+			return securityUpdatesOnJoin, nil
+		}
+	}
+	return "", fmt.Errorf("unsupported security updates on join value: %s", s)
 }
 
 // NodeTaint represents a taint applied to a Kubernetes node.
@@ -304,9 +338,14 @@ type CreateNodePool struct {
 	NodeAutoReplacement bool                    `json:"enableNodeAutoReplacement" yaml:"EnableNodeAutoReplacement"`
 	EnableNodeReboots   bool                    `json:"enableNodeReboots" yaml:"EnableNodeReboots"`
 	UpgradeStrategy     NodePoolUpgradeStrategy `json:"upgradeStrategy,omitempty" yaml:"UpgradeStrategy"`
-	Annotations         map[string]string       `json:"annotations" yaml:"Annotations"`
-	Labels              map[string]string       `json:"labels" yaml:"Labels"`
-	Taints              []NodeTaint             `json:"taints" yaml:"Taints"`
+	// SecurityUpdatesOnJoin controls whether OS security updates are installed during node bring-up,
+	// before the node joins the cluster (INSTALL_AND_REBOOT also reboots first if required).
+	// Applies to the first join only, not to upgrades of existing nodes.
+	// Omitted when empty: the server then defaults to OFF on create and keeps the stored value on update.
+	SecurityUpdatesOnJoin NodePoolSecurityUpdatesOnJoin `json:"securityUpdatesOnJoin,omitempty" yaml:"SecurityUpdatesOnJoin,omitempty"`
+	Annotations           map[string]string             `json:"annotations" yaml:"Annotations"`
+	Labels                map[string]string             `json:"labels" yaml:"Labels"`
+	Taints                []NodeTaint                   `json:"taints" yaml:"Taints"`
 }
 
 type ClusterMetadataResponse struct {

--- a/pkg/acloudapi/nodepools_test.go
+++ b/pkg/acloudapi/nodepools_test.go
@@ -1,0 +1,130 @@
+package acloudapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCreateNodePoolSecurityUpdatesOnJoin(t *testing.T) {
+	tests := []struct {
+		name                  string
+		securityUpdatesOnJoin NodePoolSecurityUpdatesOnJoin
+		wantInBody            bool
+	}{
+		{
+			name:                  "unset is omitted from the request body",
+			securityUpdatesOnJoin: "",
+			wantInBody:            false,
+		},
+		{
+			name:                  "off",
+			securityUpdatesOnJoin: NodePoolSecurityUpdatesOnJoinOff,
+			wantInBody:            true,
+		},
+		{
+			name:                  "install",
+			securityUpdatesOnJoin: NodePoolSecurityUpdatesOnJoinInstall,
+			wantInBody:            true,
+		},
+		{
+			name:                  "install-and-reboot",
+			securityUpdatesOnJoin: NodePoolSecurityUpdatesOnJoinInstallAndReboot,
+			wantInBody:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestBody map[string]any
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v1/orgs/org1/clusters/env1/cluster1/pools", func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("failed to read request body: %v", err)
+				}
+				if err := json.Unmarshal(body, &requestBody); err != nil {
+					t.Errorf("failed to unmarshal request body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"id":1,"name":"pool1","securityUpdatesOnJoin":%q}`, NodePoolSecurityUpdatesOnJoinInstall)
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			c := &clientImpl{RestyClient: NewRestyClient(nil, ClientOpts{APIUrl: server.URL})}
+			cluster := Cluster{CustomerSlug: "org1", EnvironmentSlug: "env1", Slug: "cluster1"}
+			nodePool, err := c.CreateNodePool(context.Background(), cluster, CreateNodePool{
+				Name:                  "pool1",
+				SecurityUpdatesOnJoin: tt.securityUpdatesOnJoin,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got, inBody := requestBody["securityUpdatesOnJoin"]
+			if inBody != tt.wantInBody {
+				t.Fatalf("securityUpdatesOnJoin in request body = %v, want %v", inBody, tt.wantInBody)
+			}
+			if tt.wantInBody && got != string(tt.securityUpdatesOnJoin) {
+				t.Fatalf("securityUpdatesOnJoin in request body = %v, want %v", got, tt.securityUpdatesOnJoin)
+			}
+			if nodePool.SecurityUpdatesOnJoin != NodePoolSecurityUpdatesOnJoinInstall {
+				t.Fatalf("unexpected securityUpdatesOnJoin in response: %v", nodePool.SecurityUpdatesOnJoin)
+			}
+		})
+	}
+}
+
+func TestUpdateNodePoolSecurityUpdatesOnJoinOmittedWhenUnset(t *testing.T) {
+	var rawBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/orgs/org1/clusters/env1/cluster1/pools/1", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		rawBody = body
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":1,"name":"pool1"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := &clientImpl{RestyClient: NewRestyClient(nil, ClientOpts{APIUrl: server.URL})}
+	cluster := Cluster{CustomerSlug: "org1", EnvironmentSlug: "env1", Slug: "cluster1"}
+	nodePool, err := c.UpdateNodePool(context.Background(), cluster, 1, CreateNodePool{Name: "pool1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(string(rawBody), "securityUpdatesOnJoin") {
+		t.Fatalf("expected securityUpdatesOnJoin to be omitted from request body, got: %s", rawBody)
+	}
+	if nodePool.SecurityUpdatesOnJoin != "" {
+		t.Fatalf("unexpected securityUpdatesOnJoin in response: %v", nodePool.SecurityUpdatesOnJoin)
+	}
+}
+
+func TestParseNodePoolSecurityUpdatesOnJoin(t *testing.T) {
+	for _, securityUpdatesOnJoin := range AllNodePoolSecurityUpdatesOnJoin {
+		t.Run(string(securityUpdatesOnJoin), func(t *testing.T) {
+			got, err := ParseNodePoolSecurityUpdatesOnJoin(string(securityUpdatesOnJoin))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != securityUpdatesOnJoin {
+				t.Fatalf("ParseNodePoolSecurityUpdatesOnJoin() = %v, want %v", got, securityUpdatesOnJoin)
+			}
+		})
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		if _, err := ParseNodePoolSecurityUpdatesOnJoin("invalid"); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Syncs the node pool types with platform-api, which gained a new node pool setting `securityUpdatesOnJoin` (AME-4152/AME-4154). The setting controls whether OS security updates are installed during node bring-up, before the node joins the cluster (`INSTALL_AND_REBOOT` also reboots first if required); it applies to the first join only, not to upgrades of existing nodes. A field-by-field comparison against the platform-api DTOs showed this was the only missing field in the request and response structs.

## Changes

- add `NodePoolSecurityUpdatesOnJoin` typed string with constants `OFF`, `INSTALL`, `INSTALL_AND_REBOOT`, plus `AllNodePoolSecurityUpdatesOnJoin` and `ParseNodePoolSecurityUpdatesOnJoin`, mirroring how `NodePoolUpgradeStrategy` is modelled
- add `SecurityUpdatesOnJoin` to `CreateNodePool` and `NodePools` with `omitempty`: the empty value is never sent, so the server defaults to `OFF` on create and keeps the stored value on update
- add `SecurityUpdatesOnJoin` to the `NodePool` response struct